### PR TITLE
Migrate scape-bot over to strict mode

### DIFF
--- a/src/boss-utility.ts
+++ b/src/boss-utility.ts
@@ -1,5 +1,5 @@
 import { camelize } from './util';
-import { FORMATTED_BOSS_NAMES } from 'osrs-json-hiscores';
+import { FORMATTED_BOSS_NAMES, Boss } from 'osrs-json-hiscores';
 
 /**
  * Boss name with capitalization and spacing
@@ -25,8 +25,8 @@ export function toSortedBosses(bosses: string[]): string[] {
  * @param {BossName} bossName
  * @returns {BossID}
  */
-export function sanitizeBossName(bossName: string): string {
-    const bossID = camelize(bossName).replace(/\W/g, '');
+export function sanitizeBossName(bossName: string): Boss {
+    const bossID = camelize(bossName).replace(/\W/g, '') as Boss;
     return bossID;
 }
 
@@ -35,7 +35,7 @@ export function sanitizeBossName(bossName: string): string {
  * @param {BossID} bossID
  * @returns {BossName}
  */
-export function getBossName(bossID: string): string {
+export function getBossName(bossID: Boss): string {
     return FORMATTED_BOSS_NAMES[bossID] ?? 'Unknown';
 }
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -112,15 +112,13 @@ client.on('ready', async () => {
         await deserializeState(serializedState);
         // Compute timestamp if it's present (should only be missing the very first time)
         if (state.hasTimestamp()) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            downtimeMillis = new Date().getTime() - state.getTimestamp()!.getTime();
+            downtimeMillis = new Date().getTime() - state.getTimestamp().getTime();
         }
     }
 
     // Default the tracking channel to the owner's DM if necessary...
     if (state.hasTrackingChannel()) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const trackingChannel: TextBasedChannel = state.getTrackingChannel()!;
+        const trackingChannel: TextBasedChannel = state.getTrackingChannel();
         log.push(`Loaded up tracking channel '${trackingChannel}' of type '${trackingChannel.type}' with ID '${trackingChannel.id}'`);
     } else if (ownerDmChannel) {
         state.setTrackingChannel(ownerDmChannel);

--- a/src/circular-queue.ts
+++ b/src/circular-queue.ts
@@ -51,7 +51,7 @@ class CircularQueue<T> {
         this._index = 0;
     }
 
-    getNext(): T {
+    getNext(): T | undefined {
         if (this._list.length === 0) {
             return undefined;
         }

--- a/src/command-reader.ts
+++ b/src/command-reader.ts
@@ -12,7 +12,9 @@ class CommandReader {
         try {
             parsedCommand = CommandReader.parseCommand(msg.content);
         } catch (err) {
-            log.push(`Failed to parse command '${msg.content}': ${err.toString()}`);
+            if (err instanceof Error) {
+                log.push(`Failed to parse command '${msg.content}': ${err.toString()}`);
+            }
             return;
         }
         // Execute command
@@ -26,7 +28,9 @@ class CommandReader {
                     commandInfo.fn(msg, rawArgs, ...args);
                     log.push(`Executed command '${command}' with args ${JSON.stringify(args)}`);
                 } catch (err) {
-                    log.push(`Uncaught error while trying to execute command '${msg.content}': ${err.toString()}`);
+                    if (err instanceof Error) {
+                        log.push(`Uncaught error while trying to execute command '${msg.content}': ${err.toString()}`);
+                    }
                 }
             }
         } else if (command) {

--- a/src/file-storage.ts
+++ b/src/file-storage.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { AnyObject } from './types';
 
 class FileStorage {
     readonly _basePath: string;
@@ -23,15 +24,15 @@ class FileStorage {
         return fs.readFileSync(this._basePath + id, this._ENCODING);
     }
 
-    async readJson(id: string): Promise<any> {
+    async readJson(id: string): Promise<AnyObject> {
         return JSON.parse(await this.read(id));
     }
 
-    readJsonSync(id: string): any {
+    readJsonSync(id: string): AnyObject {
         return JSON.parse(this.readSync(id));
     }
 
-    async write(id: string, value: any): Promise<void> {
+    async write(id: string, value: AnyObject | string | number): Promise<void> {
         return new Promise<void>((resolve, reject) => {
             fs.writeFile(this._basePath + id, value.toString(), (err) => {
                 if (err) {

--- a/src/load-json.ts
+++ b/src/load-json.ts
@@ -1,7 +1,8 @@
 import FileStorage from './file-storage';
+import { AnyObject } from './types';
 
 const rootStorage = new FileStorage('./');
 
-export function loadJson(path: string): any {
+export function loadJson(path: string): AnyObject {
     return rootStorage.readJsonSync(path);
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -80,7 +80,10 @@ class State {
         return !this._playersOffHiScores.has(player);
     }
 
-    getTrackingChannel(): TextBasedChannel | undefined {
+    getTrackingChannel(): TextBasedChannel {
+        if (!this._trackingChannel) {
+            throw new Error('Tracking channel does not exist');
+        }
         return this._trackingChannel;
     }
 
@@ -155,7 +158,10 @@ class State {
         return this._timestamp !== undefined;
     }
 
-    getTimestamp(): Date | undefined {
+    getTimestamp(): Date {
+        if (!this._timestamp) {
+            throw new Error('Timestamp does not exist');
+        }
         return this._timestamp;
     }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -80,7 +80,7 @@ class State {
         return !this._playersOffHiScores.has(player);
     }
 
-    getTrackingChannel(): TextBasedChannel {
+    getTrackingChannel(): TextBasedChannel | undefined {
         return this._trackingChannel;
     }
 
@@ -155,7 +155,7 @@ class State {
         return this._timestamp !== undefined;
     }
 
-    getTimestamp(): Date {
+    getTimestamp(): Date | undefined {
         return this._timestamp;
     }
 
@@ -165,10 +165,10 @@ class State {
 
     serialize(): SerializedState {
         return {
-            timestamp: this._timestamp.toJSON(),
+            timestamp: this._timestamp?.toJSON(),
             players: this._players.toSortedArray(),
             playersOffHiScores: Array.from(this._playersOffHiScores),
-            trackingChannelId: this._trackingChannel.id,
+            trackingChannelId: this._trackingChannel?.id,
             levels: this._levels,
             bosses: this._bosses,
             botCounters: this._botCounters

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,12 @@
 import { Message, Snowflake } from 'discord.js';
 
+export interface AnyObject {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: string | number | any;
+}
+
 export interface SerializedState {
-    timestamp: string,
+    timestamp?: string,
     players: string[],
     playersOffHiScores: string[],
     trackingChannelId?: string,
@@ -22,21 +27,4 @@ export interface ParsedCommand {
     command: string,
     args: string[],
     rawArgs: string
-}
-
-export interface SkillPayload {
-    level: string,
-    xp: string,
-    rank: string
-}
-
-export interface BossPayload {
-    score: string,
-    xp: string,
-    rank: string
-}
-
-export interface PlayerPayload {
-    skills: Record<string, SkillPayload>,
-    bosses: Record<string, BossPayload>
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -315,7 +315,9 @@ export function updateKillCounts(player: string, killCounts: Record<string, numb
                 Object.keys(spoofedDiff).forEach((bossID) => {
                     if (isValidBoss(bossID)) {
                         diff[bossID] = spoofedDiff[bossID];
-                        killCounts[bossID] += diff[bossID];
+                        // I noticed we fallback on 'NaN' to designate a boss KC that is missing or not yet
+                        // in the hiscores, but this means your first positive boss KC total will sum to 'NaN'. 
+                        killCounts[bossID] = (killCounts[bossID] || 0) + diff[bossID];
                     }
                 });
             } else {

--- a/src/util.ts
+++ b/src/util.ts
@@ -106,15 +106,13 @@ export function updatePlayer(player: string, spoofedDiff?: Record<string, number
                 // If player was previously on the hiscores, take them off
                 state.removePlayerFromHiScores(player);
                 if (state.hasTrackingChannel()) {
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    sendUpdateMessage(state.getTrackingChannel()!, `**${player}** has fallen off the hiscores`, 'unhappy', { color: 12919812 });
+                    sendUpdateMessage(state.getTrackingChannel(), `**${player}** has fallen off the hiscores`, 'unhappy', { color: 12919812 });
                 }
             } else if (stats.skills.overall.rank !== -1 && !state.isPlayerOnHiScores(player)) {
                 // If player was previously off the hiscores, add them back on!
                 state.addPlayerToHiScores(player);
                 if (state.hasTrackingChannel()) {
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    sendUpdateMessage(state.getTrackingChannel()!, `**${player}** has made it back onto the hiscores`, 'happy', { color: 16569404 });
+                    sendUpdateMessage(state.getTrackingChannel(), `**${player}** has made it back onto the hiscores`, 'happy', { color: 16569404 });
                 }
             }
         }
@@ -254,8 +252,7 @@ export function updateLevels(player: string, newLevels: Record<string, number>, 
             if (newLevel === 99) {
                 const levelsGained = diff[skill];
                 if (state.hasTrackingChannel()) {
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    sendUpdateMessage(state.getTrackingChannel()!,
+                    sendUpdateMessage(state.getTrackingChannel(),
                         `**${player}** has gained `
                             + (levelsGained === 1 ? 'a level' : `**${levelsGained}** levels`)
                             + ` in **${skill}** and is now level **99**\n\n`
@@ -275,8 +272,7 @@ export function updateLevels(player: string, newLevels: Record<string, number>, 
             const skill = Object.keys(diff)[0];
             const levelsGained = diff[skill];
             if (state.hasTrackingChannel()) {
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                sendUpdateMessage(state.getTrackingChannel()!,
+                sendUpdateMessage(state.getTrackingChannel(),
                     `**${player}** has gained `
                             + (levelsGained === 1 ? 'a level' : `**${levelsGained}** levels`)
                             + ` in **${skill}** and is now level **${newLevels[skill]}**`,
@@ -290,8 +286,7 @@ export function updateLevels(player: string, newLevels: Record<string, number>, 
                 return `${levelsGained === 1 ? 'a level' : `**${levelsGained}** levels`} in **${skill}** and is now level **${newLevels[skill]}**`;
             }).join('\n');
             if (state.hasTrackingChannel()) {
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                sendUpdateMessage(state.getTrackingChannel()!, `**${player}** has gained...\n${text}`, 'overall');
+                sendUpdateMessage(state.getTrackingChannel(), `**${player}** has gained...\n${text}`, 'overall');
             }
             break;
         }
@@ -355,8 +350,7 @@ export function updateKillCounts(player: string, killCounts: Record<string, numb
                         + (killCountIncrease === 1 ? 'again' : `**${killCountIncrease}** more times`)
                         + ` and is now at **${killCounts[bossID]}** kills`;
             if (state.hasTrackingChannel()) {
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                sendUpdateMessage(state.getTrackingChannel()!, text, bossName, { color: 10363483 });
+                sendUpdateMessage(state.getTrackingChannel(), text, bossName, { color: 10363483 });
             }
             break;
         }
@@ -371,8 +365,7 @@ export function updateKillCounts(player: string, killCounts: Record<string, numb
             }).join('\n');
             if (state.hasTrackingChannel()) {
                 sendUpdateMessage(
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    state.getTrackingChannel()!,
+                    state.getTrackingChannel(),
                     `**${player}** has killed...\n${text}`,
                     getBossName(sortedBosses[0] as Boss),
                     { color: 10363483 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
       "outDir": "build",
       "esModuleInterop": true,
       "sourceMap": true,
+      "strict": true
     },
     "include": [
         "src/**/*"


### PR DESCRIPTION
_Shhhhhhhhhhh..._

Enables strict mode for the TS compiler. Most of the added code is type guards for nullable values and errors. There are definitely a few issues still, though again nothing that wasn't already an issue. I have a feeling we can simplify the boss code a bunch with the constants exposed by the new `osrs-json-hiscores` library and with the type guarantees afforded by TS.

There's one sorta awkward thing, which is that TS isn't really smart enough to infer something like `state.hasTrackingChannel` is a type guard for `state.getTrackingChannel`. For the time being, I made sure all state getters are wrapped in the appropriate hassers, and then added an assertion (`!`) that the value is not undefined or null for the compiler's sake. Then I added a comment to ignore the linter's `no-non-null-assertion` rule to shut it up.

I also noticed something when spoofing update data. If a user's boss kill count is not in the hiscores (`= NaN`), adding the increase to that sums to `NaN` and the update message is messed up. So I just fallback on `0` if the kc is `NaN` when calculating the diff.