### PR TITLE
Add /details command, separate hidden commands

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -236,7 +236,7 @@ client.on('ready', async () => {
 });
 
 client.on('messageCreate', async (msg) => {
-    // Only process messages from other users mentio
+    // Only process messages from other users mentions
     if (msg.mentions.has(client.user as ClientUser) && msg.author.id !== client.user?.id) {
         // If the message was sent by another bot, troll epic style 😈
         if (msg.author.bot) {

--- a/src/command-handler.ts
+++ b/src/command-handler.ts
@@ -9,7 +9,7 @@ import {
 } from 'discord.js';
 import { MultiLoggerLevel } from 'evanw555.js';
 import commands, { INVALID_TEXT_CHANNEL } from './commands';
-import { BuiltSlashCommand, Command, CommandName, CommandOption, CommandWithOptions } from './types';
+import { BuiltSlashCommand, SlashCommandName, CommandOption, CommandWithOptions, SlashCommand } from './types';
 
 import state from './instances/state';
 import logger from './instances/logger';
@@ -41,11 +41,11 @@ class CommandHandler {
         await interaction.respond([]);
     }
 
-    static isValidCommand(commandName: string): commandName is CommandName {
+    static isValidCommand(commandName: string): commandName is SlashCommandName {
         return Object.prototype.hasOwnProperty.call(commands, commandName);
     }
 
-    static isCommandWithOptions(command: Command): command is CommandWithOptions {
+    static isCommandWithOptions(command: SlashCommand): command is CommandWithOptions {
         return Array.isArray(command.options);
     }
 
@@ -104,7 +104,7 @@ class CommandHandler {
     }
 
     buildCommands(): ApplicationCommandDataResolvable[] {
-        const commandKeys = Object.keys(commands) as CommandName[];
+        const commandKeys = Object.keys(commands) as SlashCommandName[];
         const data: ApplicationCommandDataResolvable[] = [];
         commandKeys.forEach((key) => {
             // We can check for existence of the execute() function for now, this is only

--- a/src/command-reader.ts
+++ b/src/command-reader.ts
@@ -1,7 +1,7 @@
 import { Message } from 'discord.js';
 import { MultiLoggerLevel } from 'evanw555.js';
-import { ParsedCommand, Command, CommandName } from './types';
-import commands from './commands';
+import { ParsedCommand, HiddenCommand, HiddenCommandName } from './types';
+import { hiddenCommands } from './commands';
 
 import state from './instances/state';
 import logger from './instances/logger';
@@ -20,8 +20,9 @@ class CommandReader {
         }
         // Execute command
         const { command, args, rawArgs } = parsedCommand;
-        if (Object.prototype.hasOwnProperty.call(commands, command)) {
-            const commandInfo: Command = commands[command as CommandName];
+        if (Object.prototype.hasOwnProperty.call(hiddenCommands, command)) {
+            const commandName = command as HiddenCommandName;
+            const commandInfo: HiddenCommand = hiddenCommands[commandName];
             if (commandInfo.privileged && !state.isAdmin(msg.author.id)) {
                 msg.channel.send('You can\'t do that');
             } else if (commandInfo.failIfDisabled && state.isDisabled()) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -255,7 +255,8 @@ const slashCommands: SlashCommandsType = {
                 });
             }
         },
-        text: 'Show details of when each tracked player was last updated'
+        text: 'Show details of when each tracked player was last updated',
+        privileged: true
     }
 };
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,11 +1,11 @@
-import { ApplicationCommandOptionType, ChatInputCommandInteraction, Message, Snowflake, TextBasedChannel } from 'discord.js';
+import { ApplicationCommandOptionType, ChatInputCommandInteraction, Message, PermissionFlagsBits, TextBasedChannel } from 'discord.js';
 import { FORMATTED_BOSS_NAMES, Boss, BOSSES } from 'osrs-json-hiscores';
 import { exec } from 'child_process';
 import { MultiLoggerLevel, randChoice, randInt } from 'evanw555.js';
-import { Command, PlayerHiScores, CommandName } from './types';
+import { SlashCommandName, HiddenCommand, PlayerHiScores, SlashCommand, HiddenCommandName, Command } from './types';
 import { replyUpdateMessage, sendUpdateMessage, updatePlayer, getBossName, isValidBoss } from './util';
 import { fetchHiScores } from './hiscores';
-import { CLUES_NO_ALL, SKILLS_NO_OVERALL, CONSTANTS, CONFIG, BOSS_CHOICES, SKILL_CHOICES } from './constants';
+import { CLUES_NO_ALL, SKILLS_NO_OVERALL, CONSTANTS, CONFIG, BOSS_CHOICES } from './constants';
 import { deleteTrackedPlayer, insertTrackedPlayer, updateTrackingChannel } from './pg-storage';
 
 import state from './instances/state';
@@ -16,16 +16,24 @@ import infoLog from './instances/info-log';
 
 const validSkills = new Set<string>(CONSTANTS.skills);
 
-const getHelpText = (hidden?: boolean) => {
-    const unfilteredCommandKeys = Object.keys(commands) as CommandName[];
-    const commandKeys = unfilteredCommandKeys
-        .filter((key: CommandName) => !!commands[key].hidden === !!hidden);
+type CommandsType = Record<string, Command>;
+type SlashCommandsType = Record<SlashCommandName, SlashCommand>;
+type HiddenCommandsType = Record<HiddenCommandName, HiddenCommand>;
+
+const getHelpText = (hidden: boolean, privileged = false) => {
+    const commands: CommandsType = hidden ? hiddenCommands : slashCommands;
+    const commandKeys = Object.keys(commands).filter((key) => {
+        if (hidden || privileged) {
+            return true;
+        }
+        return !commands[key].privileged;
+    });
     commandKeys.sort();
     const maxLengthKey = Math.max(...commandKeys.map((key) => {
         return key.length;
     }));
     const innerText = commandKeys
-        .map((key: CommandName) => `${key.padEnd(maxLengthKey)} :: ${commands[key].text}`)
+        .map(key => `${hidden ? '' : '/'}${key.padEnd(maxLengthKey)} :: ${commands[key].text}`)
         .join('\n');
     return `\`\`\`asciidoc\n${innerText}\`\`\``;
 };
@@ -39,7 +47,8 @@ const getInteractionGuildId = (interaction: ChatInputCommandInteraction): string
     return interaction.guildId;
 };
 
-const commands: Record<CommandName, Command> = {
+
+const slashCommands: SlashCommandsType = {
     ping: {
         execute: async (interaction) => {
             await interaction.reply('pong!');
@@ -47,15 +56,13 @@ const commands: Record<CommandName, Command> = {
         text: 'Replies with pong!'
     },
     help: {
-        fn: (msg) => {
-            msg.channel.send(getHelpText(false));
+        execute: async (interaction) => {
+            const isAdmin = interaction.memberPermissions?.has(PermissionFlagsBits.Administrator);
+            await interaction.reply({ content: getHelpText(false, isAdmin), ephemeral: true });
         },
         text: 'Shows help'
     },
     track: {
-        fn: async (msg) => {
-            await msg.channel.send('Use the **/track** command');
-        },
         options: [{
             type: ApplicationCommandOptionType.String,
             name: 'username',
@@ -82,9 +89,6 @@ const commands: Record<CommandName, Command> = {
         failIfDisabled: true
     },
     remove: {
-        fn: async (msg) => {
-            await msg.channel.send('Use the **/remove** command');
-        },
         options: [{
             type: ApplicationCommandOptionType.String,
             name: 'username',
@@ -110,9 +114,6 @@ const commands: Record<CommandName, Command> = {
         failIfDisabled: true
     },
     clear: {
-        fn: async (msg) => {
-            await msg.channel.send('Use the **/clear** command');
-        },
         execute: async (interaction) => {
             const guildId = getInteractionGuildId(interaction);
             // TODO: Can we add a batch delete operation?
@@ -127,9 +128,6 @@ const commands: Record<CommandName, Command> = {
         failIfDisabled: true
     },
     list: {
-        fn: async (msg) => {
-            await msg.channel.send('Use the **/list** command');
-        },
         execute: async (interaction) => {
             const guildId = getInteractionGuildId(interaction);
             if (state.isTrackingAnyPlayers(guildId)) {
@@ -144,9 +142,6 @@ const commands: Record<CommandName, Command> = {
         text: 'Lists all the players currently being tracked'
     },
     check: {
-        fn: async (msg) => {
-            await msg.channel.send('Use the **/check** command');
-        },
         options: [{
             type: ApplicationCommandOptionType.String,
             name: 'username',
@@ -186,9 +181,6 @@ const commands: Record<CommandName, Command> = {
         failIfDisabled: true
     },
     kc: {
-        fn: async (msg) => {
-            await msg.channel.send('Use the **/kc** command');
-        },
         options: [
             {
                 type: ApplicationCommandOptionType.String,
@@ -235,9 +227,6 @@ const commands: Record<CommandName, Command> = {
         failIfDisabled: true
     },
     channel: {
-        fn: async (msg) => {
-            await msg.channel.send('Use the **/channel** command');
-        },
         execute: async (interaction) => {
             const guildId = getInteractionGuildId(interaction);
             await updateTrackingChannel(guildId, interaction.channelId);
@@ -249,54 +238,33 @@ const commands: Record<CommandName, Command> = {
         privileged: true,
         failIfDisabled: true
     },
-    hiddenhelp: {
-        fn: (msg) => {
-            msg.channel.send(getHelpText(true));
-        },
-        hidden: true,
-        text: 'Shows help for hidden commands',
-        privileged: true
-    },
     details: {
-        fn: (msg) => {
-            const guildId: Snowflake | null = msg.guildId;
-            if (!guildId) {
-                msg.reply('This command can only be used in a guild text channel!');
-                return;
-            }
+        execute: async (interaction) => {
+            const guildId = getInteractionGuildId(interaction);
 
             if (state.isTrackingAnyPlayers(guildId)) {
                 const sortedPlayers = state.getAllTrackedPlayers(guildId);
-                msg.channel.send(`${sortedPlayers.map(rsn => `**${rsn}**: last updated **${state.getLastUpdated(rsn)?.toLocaleTimeString('en-US', { timeZone: CONFIG.timeZone })}**`).join('\n')}`);
+                await interaction.reply({
+                    content: `${sortedPlayers.map(rsn => `**${rsn}**: last updated **${state.getLastUpdated(rsn)?.toLocaleTimeString('en-US', { timeZone: CONFIG.timeZone })}**`).join('\n')}`,
+                    ephemeral: true
+                });
             } else {
-                msg.channel.send('Currently not tracking any players');
+                await interaction.reply({
+                    content: 'Currently not tracking any players',
+                    ephemeral: true
+                });
             }
         },
         text: 'Show details of when each tracked player was last updated'
-    },
-    hey: {
-        fn: (msg) => {
-            msg.channel.send('Sup');
-        },
-        hidden: true,
-        text: 'Hey'
-    },
-    sup: {
-        fn: (msg) => {
-            msg.channel.send('Hey');
-        },
-        hidden: true,
-        text: 'Sup'
-    },
-    log: {
-        fn: (msg) => {
-            // Truncate both logs to the Discord max of 2000 characters
-            msg.channel.send(`Info Log:\n\`\`\`${infoLog.toLogArray().join('\n').slice(0, 1950) || 'log empty'}\`\`\``);
-            msg.channel.send(`Debug Log:\`\`\`${debugLog.toLogArray().join('\n').slice(0, 1950) || 'log empty'}\`\`\``);
-        },
-        hidden: true,
-        text: 'Prints the bot\'s log'
-    },
+    }
+};
+
+
+/**
+ * These commands are accessible only to the user matching the adminUserId
+ * specified in the config, and are invoked using the old command reader.
+ */
+export const hiddenCommands: HiddenCommandsType = {
     thumbnail: {
         fn: (msg, rawArgs, name) => {
             if (validSkills.has(name)) {
@@ -311,31 +279,6 @@ const commands: Record<CommandName, Command> = {
                 msg.channel.send(`**${name || '[none]'}** does not have a thumbnail`);
             }
         },
-        options: [{
-            type: ApplicationCommandOptionType.String,
-            name: 'name',
-            description: 'Name',
-            required: true,
-            choices: BOSS_CHOICES.concat(SKILL_CHOICES)
-        }],
-        execute: async (interaction) => {
-            const name = interaction.options.getString('name', true);
-            if (validSkills.has(name)) {
-                await replyUpdateMessage(interaction, 'Here is the thumbnail', name, {
-                    title: name
-                });
-            } else if (isValidBoss(name)) {
-                await replyUpdateMessage(interaction, 'Here is the thumbnail', name, {
-                    title: name
-                });
-            } else {
-                await interaction.reply({
-                    content: `**${name || '[none]'}** does not have a thumbnail`,
-                    ephemeral: true
-                });
-            }
-        },
-        hidden: true,
         text: 'Displays a skill or boss\' thumbnail'
     },
     thumbnail99: {
@@ -349,8 +292,22 @@ const commands: Record<CommandName, Command> = {
                 msg.channel.send(`**${skill || '[none]'}** is not a valid skill`);
             }
         },
-        hidden: true,
         text: 'Displays a skill\'s level 99 thumbnail'
+    },
+    help: {
+        fn: (msg) => {
+            msg.channel.send(getHelpText(true));
+        },
+        text: 'Shows help for hidden commands',
+        privileged: true
+    },
+    log: {
+        fn: (msg) => {
+            // Truncate both logs to the Discord max of 2000 characters
+            msg.channel.send(`Info Log:\n\`\`\`${infoLog.toLogArray().join('\n').slice(0, 1950) || 'log empty'}\`\`\``);
+            msg.channel.send(`Debug Log:\`\`\`${debugLog.toLogArray().join('\n').slice(0, 1950) || 'log empty'}\`\`\``);
+        },
+        text: 'Prints the bot\'s log'
     },
     spoofverbose: {
         fn: (msg, rawArgs) => {
@@ -367,7 +324,6 @@ const commands: Record<CommandName, Command> = {
             }
             updatePlayer(player, spoofedDiff);
         },
-        hidden: true,
         text: 'Spoof an update notification using a raw JSON object {player, diff: {skills|bosses}}',
         failIfDisabled: true
     },
@@ -388,7 +344,6 @@ const commands: Record<CommandName, Command> = {
                 msg.channel.send('Usage: spoof PLAYER');
             }
         },
-        hidden: true,
         text: 'Spoof an update notification for some player with random skill/boss updates',
         failIfDisabled: true
     },
@@ -406,7 +361,6 @@ const commands: Record<CommandName, Command> = {
                 }
             });
         },
-        hidden: true,
         text: 'Show the uptime of the host (not the bot)'
     },
     kill: {
@@ -423,7 +377,6 @@ const commands: Record<CommandName, Command> = {
                 process.exit(1);
             });
         },
-        hidden: true,
         text: 'Kills the bot',
         privileged: true
     },
@@ -457,7 +410,6 @@ const commands: Record<CommandName, Command> = {
     //                 msg.reply(`Could not serialize state:\n\`\`\`${reason.toString()}\`\`\``);
     //             });
     //     },
-    //     hidden: true,
     //     text: 'Prints the bot\'s state',
     //     privileged: true
     // },
@@ -466,10 +418,9 @@ const commands: Record<CommandName, Command> = {
             msg.reply('Enabling the bot... If the API format is still not supported, the bot will disable itself.');
             state.setDisabled(false);
         },
-        hidden: true,
         text: 'Enables the bot, this should be used after the bot has been disabled due to an incompatible API change',
         privileged: true
     }
 };
 
-export default commands;
+export default slashCommands;

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,12 +55,9 @@ export type MiscFlagName = 'timestamp' | 'disabled';
 
 export type BuiltSlashCommand = SlashCommandBuilder | Omit<SlashCommandBuilder, 'addSubcommand' | 'addSubcommandGroup'>;
 
-export type DeprecatedCommandName =  'help' | 'hiddenhelp' | 'details' | 'hey' | 'sup' | 'log'
-| 'thumbnail99' | 'spoof' | 'spoofverbose' | 'uptime' | 'kill' | 'enable';
+export type SlashCommandName = 'help' | 'ping' | 'track' | 'remove' | 'clear' | 'list' | 'check' | 'channel' | 'kc' | 'details';
 
-export type SlashCommandName = 'ping' | 'track' | 'remove' | 'clear' | 'list' | 'check' | 'channel' | 'kc' | 'thumbnail';
-
-export type CommandName = DeprecatedCommandName | SlashCommandName;
+export type HiddenCommandName = 'help' | 'log' | 'thumbnail' | 'thumbnail99' | 'spoof' | 'spoofverbose' | 'uptime' | 'kill' | 'enable';
 
 export interface CommandOptionChoice {
     name: string,
@@ -76,16 +73,21 @@ export interface CommandOption {
 }
 
 export interface Command {
-    fn?: (msg: Message, rawArgs: string, ...args: string[]) => void,
-    execute?: (interaction: ChatInputCommandInteraction) => Promise<void>,
     text: string,
-    options?: CommandOption[],
-    hidden?: boolean,
     privileged?: boolean,
     failIfDisabled?: boolean
 }
 
-export interface CommandWithOptions extends Command {
+export interface SlashCommand extends Command {
+    options?: CommandOption[]
+    execute: (interaction: ChatInputCommandInteraction) => Promise<void>,
+}
+
+export interface HiddenCommand extends Command {
+    fn: (msg: Message, rawArgs: string, ...args: string[]) => void
+}
+
+export interface CommandWithOptions extends SlashCommand {
     options: CommandOption[]
 }
 


### PR DESCRIPTION
- Implements last 2 slash commands: `/details` and `/help`
- Moves remaining commands to a separately typed `hiddenCommands` map
- Improves help command to respect Discord admin role
- Removes unnecessary commands 'sup' and 'hey' (I'm personally conflicted about this one)

This should complete the great slash command migration. It also presents what I think is probably the best option for having your own personal debug commands. They obviously can't be slash commands, because at the very least every guild admin would see them. So we'll just keep the existing command reader and use it for your debug commands. Anyone could technically @ScapeBot and call one of the 'hidden' commands but it would reject their request on the premise of them not having your `adminUserId`.

A possible improvement would be to reject any handling of `messageCreate` that isn't authored by the `adminUserId` user or a Discord bot.