### PR TITLE
Implement guild-specific settings

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -230,6 +230,16 @@ const loadState = async (): Promise<void> => {
             }
         }
     }
+    const guildSettings = await pgStorageClient.fetchAllGuildSettings();
+    for (const [ guildId, settings ] of Object.entries(guildSettings)) {
+        try {
+            state.setGuildSettings(guildId, settings);
+        } catch (err) {
+            if (err instanceof Error) {
+                await logger.log(`Failed to set settings for guild ${guildId} due to ${err.toString()}`, MultiLoggerLevel.Error);
+            }
+        }
+    }
     for (const rsn of playersOffHiScores) {
         state.removePlayerFromHiScores(rsn);
     }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,14 +1,14 @@
 import { BOSSES, CLUES } from 'osrs-json-hiscores';
 import { Client, ClientUser, Guild, GatewayIntentBits, Options, TextBasedChannel, User, TextChannel, ActivityType, Snowflake, PermissionFlagsBits, MessageCreateOptions, GuildResolvable } from 'discord.js';
 import { DailyAnalyticsLabel, TimeoutType } from './types';
-import { sendUpdateMessage, getQuantityWithUnits, getThumbnail, getNextFridayEvening, updatePlayer, getNextEvening, getGuildWarningEmbeds, createWarningEmbed, purgeUntrackedPlayers, getHelpComponents, readDir, getAnalyticsTrendsString, getUnambiguousQuantitiesWithUnits } from './util';
+import { sendUpdateMessage, getQuantityWithUnits, getThumbnail, getNextFridayEvening, updatePlayer, getNextEvening, getGuildWarningEmbeds, getGuildSettingOrDefault, createWarningEmbed, purgeUntrackedPlayers, getHelpComponents, readDir, getAnalyticsTrendsString, getUnambiguousQuantitiesWithUnits } from './util';
 import { TimeoutManager, PastTimeoutStrategy, randInt, getDurationString, sleep, MultiLoggerLevel, naturalJoin, getPreciseDurationString, toDiscordTimestamp, DiscordTimestampFormat } from 'evanw555.js';
 import CommandReader from './command-reader';
 import CommandHandler from './command-handler';
 import commands from './commands';
 import TimeoutStorage from './timeout-storage';
 
-import { AUTH, CONFIG, DEFAULT_GUILD_SETTINGS, GUILD_SETTINGS_MAP, INACTIVE_THRESHOLD_MILLIES, OTHER_ACTIVITIES, RED_EMBED_COLOR, SKILLS_NO_OVERALL, TIMEOUTS_PROPERTY } from './constants';
+import { AUTH, CONFIG, GUILD_SETTINGS_MAP, INACTIVE_THRESHOLD_MILLIES, OTHER_ACTIVITIES, RED_EMBED_COLOR, SKILLS_NO_OVERALL, TIMEOUTS_PROPERTY } from './constants';
 
 import state from './instances/state';
 import logger from './instances/logger';
@@ -439,7 +439,7 @@ const weeklyTotalXpUpdate = async () => {
             try {
                 // Get the top XP earners for this guild
                 const weeklyRankingSetting = GUILD_SETTINGS_MAP.WEEKLY_RANKING_MAX_COUNT;
-                const weeklyRankingMaxCount = state.getGuildSetting(guildId, weeklyRankingSetting) ?? DEFAULT_GUILD_SETTINGS[weeklyRankingSetting];
+                const weeklyRankingMaxCount = getGuildSettingOrDefault(guildId, weeklyRankingSetting);
                 const winners: string[] = sortedPlayers.filter(rsn => state.isTrackingPlayer(guildId, rsn)).slice(0, weeklyRankingMaxCount);
 
                 // Only send out a message if there are any XP earners

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,11 +1,11 @@
-import { ApplicationCommandOptionType, AttachmentBuilder, ChatInputCommandInteraction, Guild, PermissionFlagsBits, TextChannel } from 'discord.js';
+import { ApplicationCommandOptionType, AttachmentBuilder, ChatInputCommandInteraction, EmbedBuilder, Guild, PermissionFlagsBits, TextChannel } from 'discord.js';
 import { Boss, BOSSES } from 'osrs-json-hiscores';
 import { MultiLoggerLevel, naturalJoin } from 'evanw555.js';
 import { PlayerHiScores, SlashCommandsType } from './types';
-import { replyUpdateMessage, updatePlayer, getBossName, generateDetailsContentString, sanitizeRSN, botHasRequiredPermissionsInChannel, validateRSN, getMissingRequiredChannelPermissionNames, getGuildWarningEmbeds, createWarningEmbed, purgeUntrackedPlayers, getHelpComponents, getHelpText, resolveHiScoresUrlTemplate } from './util';
+import { replyUpdateMessage, updatePlayer, getBossName, generateDetailsContentString, sanitizeRSN, botHasRequiredPermissionsInChannel, validateRSN, getMissingRequiredChannelPermissionNames, getGuildWarningEmbeds, createWarningEmbed, purgeUntrackedPlayers, getHelpComponents, getHelpText, isValidGuildSetting, buildGuildSettingsFields, resolveHiScoresUrlTemplate } from './util';
 import { fetchHiScores, isPlayerNotFoundError } from './hiscores';
 import CommandHandler from './command-handler';
-import { AUTH, CLUES_NO_ALL, SKILLS_NO_OVERALL, CONSTANTS, BOSS_CHOICES, INVALID_TEXT_CHANNEL, SKILL_EMBED_COLOR, OTHER_ACTIVITIES, OTHER_ACTIVITIES_MAP } from './constants';
+import { AUTH, CLUES_NO_ALL, SKILLS_NO_OVERALL, CONSTANTS, BOSS_CHOICES, INVALID_TEXT_CHANNEL, SKILL_EMBED_COLOR, OTHER_ACTIVITIES, OTHER_ACTIVITIES_MAP, DEFAULT_GUILD_SETTINGS } from './constants';
 
 import state from './instances/state';
 import logger from './instances/logger';
@@ -344,8 +344,36 @@ const slashCommands: SlashCommandsType = {
     settings: {
         subcommands: [
             {
+                name: 'info',
+                description: 'Displays current settings for this server',
+                execute: async (interaction) => {
+                    const guildId = getInteractionGuildId(interaction);
+                    try {                            
+                        const savedSettings = state.getGuildSettings(guildId);
+                        // Merge the saved settings with the default settings
+                        const guildSettings = { ...DEFAULT_GUILD_SETTINGS, ...savedSettings };
+                        const settingsFields = buildGuildSettingsFields(guildSettings);
+                        const embed = new EmbedBuilder()
+                            .setColor(0x0099FF)
+                            .setTitle('ScapeBot Settings')
+                            .addFields(...settingsFields);
+                        await interaction.reply({
+                            embeds: [embed],
+                            ephemeral: true
+                        });
+                        return true;
+                    } catch (err) {
+                        if (err instanceof Error) {
+                            await logger.log(`Error while getting settings for guild ${interaction.guildId}: ${err.toString()}`, MultiLoggerLevel.Error);
+                            await interaction.reply(`Couldn't get settings: ${err.toString()}`);
+                        }
+                        return false;
+                    }
+                }
+            },
+            {
                 name: 'skills_broadcast_every_10',
-                description: 'Broadcast skill updates every 10 levels up to this level',
+                description: 'Broadcast skill updates for every 10th level-up, starting from this value',
                 options: [
                     {
                         type: ApplicationCommandOptionType.Integer,
@@ -357,7 +385,7 @@ const slashCommands: SlashCommandsType = {
             },
             {
                 name: 'skills_broadcast_every_5',
-                description: 'Broadcast skill updates every 5 levels up to this level',
+                description: 'Broadcast skill updates for every 5th level-up, starting from this value',
                 options: [
                     {
                         type: ApplicationCommandOptionType.Integer,
@@ -369,7 +397,7 @@ const slashCommands: SlashCommandsType = {
             },
             {
                 name: 'skills_broadcast_every_1',
-                description: 'Broadcast skill updates every level up to this level',
+                description: 'Broadcast skill updates for every level-up, starting from this value',
                 options: [
                     {
                         type: ApplicationCommandOptionType.Integer,
@@ -381,7 +409,7 @@ const slashCommands: SlashCommandsType = {
             },
             {
                 name: 'bosses_broadcast_interval',
-                description: 'Broadcast boss kills at this interval (e.g. every 1, 5, 10)',
+                description: 'Broadcast boss kills at every multiple of this value (e.g. every 1, 5, 10)',
                 options: [
                     {
                         type: ApplicationCommandOptionType.Integer,
@@ -393,7 +421,7 @@ const slashCommands: SlashCommandsType = {
             },
             {
                 name: 'clues_broadcast_interval',
-                description: 'Broadcast clue completions at this interval (e.g. every 1, 5, 10)',
+                description: 'Broadcast clue completions at every multiple of this value (e.g. every 1, 5, 10)',
                 options: [
                     {
                         type: ApplicationCommandOptionType.Integer,
@@ -405,7 +433,7 @@ const slashCommands: SlashCommandsType = {
             },
             {
                 name: 'minigames_broadcast_interval',
-                description: 'Broadcast minigame completions at this interval (e.g. every 1, 5, 10)',
+                description: 'Broadcast minigame completions at every multiple of this value (e.g. every 1, 5, 10)',
                 options: [
                     {
                         type: ApplicationCommandOptionType.Integer,
@@ -429,10 +457,21 @@ const slashCommands: SlashCommandsType = {
             }
         ],
         execute: async (interaction) => {
+            const guildId = getInteractionGuildId(interaction);
             try {
                 const value = interaction.options.getInteger('value', true);
+                const setting = interaction.options.getSubcommand(true);
+                if (!isValidGuildSetting(setting)) {
+                    await interaction.reply({
+                        content: `Invalid setting: **${setting}**`,
+                        ephemeral: true
+                    });
+                    return false;
+                }
+                await pgStorageClient.writeGuildSetting(guildId, setting, value);
+                state.setGuildSetting(guildId, setting, value);
                 await interaction.reply({
-                    content: `${interaction.options.getSubcommand()}: ${value}`,
+                    content: `Setting **${interaction.options.getSubcommand()}** set to **${value}**`,
                     ephemeral: true
                 });
                 return true;
@@ -445,6 +484,7 @@ const slashCommands: SlashCommandsType = {
             }
         },
         text: 'Configure ScapeBot settings for this server',
+        admin: true,
         failIfDisabled: true
     },
     channel: {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -341,6 +341,112 @@ const slashCommands: SlashCommandsType = {
         text: 'Shows the kill count of a boss for some player',
         failIfDisabled: true
     },
+    settings: {
+        subcommands: [
+            {
+                name: 'skills_broadcast_every_10',
+                description: 'Broadcast skill updates every 10 levels up to this level',
+                options: [
+                    {
+                        type: ApplicationCommandOptionType.Integer,
+                        name: 'value',
+                        description: 'Level',
+                        required: true
+                    }
+                ]
+            },
+            {
+                name: 'skills_broadcast_every_5',
+                description: 'Broadcast skill updates every 5 levels up to this level',
+                options: [
+                    {
+                        type: ApplicationCommandOptionType.Integer,
+                        name: 'value',
+                        description: 'Level',
+                        required: true
+                    }
+                ]
+            },
+            {
+                name: 'skills_broadcast_every_1',
+                description: 'Broadcast skill updates every level up to this level',
+                options: [
+                    {
+                        type: ApplicationCommandOptionType.Integer,
+                        name: 'value',
+                        description: 'Level',
+                        required: true
+                    }
+                ]
+            },
+            {
+                name: 'bosses_broadcast_interval',
+                description: 'Broadcast boss kills at this interval (e.g. every 1, 5, 10)',
+                options: [
+                    {
+                        type: ApplicationCommandOptionType.Integer,
+                        name: 'value',
+                        description: 'Interval',
+                        required: true
+                    }
+                ]
+            },
+            {
+                name: 'clues_broadcast_interval',
+                description: 'Broadcast clue completions at this interval (e.g. every 1, 5, 10)',
+                options: [
+                    {
+                        type: ApplicationCommandOptionType.Integer,
+                        name: 'value',
+                        description: 'Interval',
+                        required: true
+                    }
+                ]
+            },
+            {
+                name: 'minigames_broadcast_interval',
+                description: 'Broadcast minigame completions at this interval (e.g. every 1, 5, 10)',
+                options: [
+                    {
+                        type: ApplicationCommandOptionType.Integer,
+                        name: 'value',
+                        description: 'Interval',
+                        required: true
+                    }
+                ]
+            },
+            {
+                name: 'weekly_ranking_max_count',
+                description: 'Number of players included in the weekly ranking',
+                options: [
+                    {
+                        type: ApplicationCommandOptionType.Integer,
+                        name: 'value',
+                        description: 'Count',
+                        required: true
+                    }
+                ]
+            }
+        ],
+        execute: async (interaction) => {
+            try {
+                const value = interaction.options.getInteger('value', true);
+                await interaction.reply({
+                    content: `${interaction.options.getSubcommand()}: ${value}`,
+                    ephemeral: true
+                });
+                return true;
+            } catch (err) {
+                if (err instanceof Error) {
+                    await logger.log(`Error while configuring settings for guild ${interaction.guildId}: ${err.toString()}`, MultiLoggerLevel.Error);
+                    await interaction.reply(`Couldn't set settings: ${err.toString()}`);
+                }
+                return false;
+            }
+        },
+        text: 'Configure ScapeBot settings for this server',
+        failIfDisabled: true
+    },
     channel: {
         execute: async (interaction) => {
             const guild = getInteractionGuild(interaction);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -371,42 +371,42 @@ const slashCommands: SlashCommandsType = {
                     }
                 }
             },
-            {
-                name: 'skills_broadcast_every_10',
-                description: 'Broadcast skill updates for every 10th level-up, starting from this value',
-                options: [
-                    {
-                        type: ApplicationCommandOptionType.Integer,
-                        name: 'value',
-                        description: 'Level',
-                        required: true
-                    }
-                ]
-            },
-            {
-                name: 'skills_broadcast_every_5',
-                description: 'Broadcast skill updates for every 5th level-up, starting from this value',
-                options: [
-                    {
-                        type: ApplicationCommandOptionType.Integer,
-                        name: 'value',
-                        description: 'Level',
-                        required: true
-                    }
-                ]
-            },
-            {
-                name: 'skills_broadcast_every_1',
-                description: 'Broadcast skill updates for every level-up, starting from this value',
-                options: [
-                    {
-                        type: ApplicationCommandOptionType.Integer,
-                        name: 'value',
-                        description: 'Level',
-                        required: true
-                    }
-                ]
-            },
+            // {
+            //     name: 'skills_broadcast_every_10',
+            //     description: 'Broadcast skill updates for every 10th level-up, starting from this value',
+            //     options: [
+            //         {
+            //             type: ApplicationCommandOptionType.Integer,
+            //             name: 'value',
+            //             description: 'Level',
+            //             required: true
+            //         }
+            //     ]
+            // },
+            // {
+            //     name: 'skills_broadcast_every_5',
+            //     description: 'Broadcast skill updates for every 5th level-up, starting from this value',
+            //     options: [
+            //         {
+            //             type: ApplicationCommandOptionType.Integer,
+            //             name: 'value',
+            //             description: 'Level',
+            //             required: true
+            //         }
+            //     ]
+            // },
+            // {
+            //     name: 'skills_broadcast_every_1',
+            //     description: 'Broadcast skill updates for every level-up, starting from this value',
+            //     options: [
+            //         {
+            //             type: ApplicationCommandOptionType.Integer,
+            //             name: 'value',
+            //             description: 'Level',
+            //             required: true
+            //         }
+            //     ]
+            // },
             {
                 name: 'bosses_broadcast_interval',
                 description: 'Broadcast boss kills at every multiple of this value (e.g. every 1, 5, 10)',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -89,32 +89,34 @@ export const DEFAULT_AXIOS_CONFIG: { timeout: number } = {
     timeout: 30000
 };
 
-export const GUILD_SETTINGS: Set<GuildSetting> = new Set([
-    'skills_broadcast_every_10',
-    'skills_broadcast_every_5',
-    'skills_broadcast_every_1',
-    'bosses_broadcast_interval',
-    'clues_broadcast_interval',
-    'minigames_broadcast_interval',
-    'weekly_ranking_max_count'
-]);
+export const GUILD_SETTINGS_MAP = {
+    SKILLS_BROADCAST_EVERY_10: 'skills_broadcast_every_10',
+    SKILLS_BROADCAST_EVERY_5: 'skills_broadcast_every_5',
+    SKILLS_BROADCAST_EVERY_1: 'skills_broadcast_every_1',
+    BOSSES_BROADCAST_INTERVAL: 'bosses_broadcast_interval',
+    CLUES_BROADCAST_INTERVAL: 'clues_broadcast_interval',
+    MINIGAMES_BROADCAST_INTERVAL: 'minigames_broadcast_interval',
+    WEEKLY_RANKING_MAX_COUNT: 'weekly_ranking_max_count'
+} as const;
 
-export const FORMATTED_GUILD_SETTINGS: Record<GuildSetting, string> = {
-    'skills_broadcast_every_10': 'Broadcast skills every 10 levels up to this level',
-    'skills_broadcast_every_5': 'Broadcast skills every 5 levels up to this level',
-    'skills_broadcast_every_1': 'Broadcast skills every level up to this level',
-    'bosses_broadcast_interval': 'Broadcast boss kills at this interval',
-    'clues_broadcast_interval': 'Broadcast clue completions at this interval',
-    'minigames_broadcast_interval': 'Broadcast minigame completions at this interval',
-    'weekly_ranking_max_count': 'Number of players included in the weekly ranking'
-};
+export const GUILD_SETTINGS: Set<GuildSetting> = new Set(Object.values(GUILD_SETTINGS_MAP) as GuildSetting[]);
 
-export const DEFAULT_GUILD_SETTINGS: Record<GuildSetting, number> = {
-    'skills_broadcast_every_10': 0,
-    'skills_broadcast_every_5': 0,
-    'skills_broadcast_every_1': 99,     // Broadcast every level-up
-    'bosses_broadcast_interval': 1,     // Broadcast every boss kill
-    'clues_broadcast_interval': 1,      // Broadcast every clue completion
-    'minigames_broadcast_interval': 1,  // Broadcast every minigame completion
-    'weekly_ranking_max_count': 3       // Show the top 3 players in the weekly ranking
-};
+export const FORMATTED_GUILD_SETTINGS = {
+    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_10]: 'Every 10th level-up starting level',
+    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_5]: 'Every 5th level-up starting level',
+    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_1]: 'Every level-up starting level',
+    [GUILD_SETTINGS_MAP.BOSSES_BROADCAST_INTERVAL]: 'Boss kills broadcast interval',
+    [GUILD_SETTINGS_MAP.CLUES_BROADCAST_INTERVAL]: 'Clue completions broadcast interval',
+    [GUILD_SETTINGS_MAP.MINIGAMES_BROADCAST_INTERVAL]: 'Minigame completions broadcast interval',
+    [GUILD_SETTINGS_MAP.WEEKLY_RANKING_MAX_COUNT]: 'Number of players in the weekly ranking'
+} as const;
+
+export const DEFAULT_GUILD_SETTINGS = {
+    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_10]: 0,
+    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_5]: 0,
+    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_1]: 1,
+    [GUILD_SETTINGS_MAP.BOSSES_BROADCAST_INTERVAL]: 1,
+    [GUILD_SETTINGS_MAP.CLUES_BROADCAST_INTERVAL]: 1,
+    [GUILD_SETTINGS_MAP.MINIGAMES_BROADCAST_INTERVAL]: 1,
+    [GUILD_SETTINGS_MAP.WEEKLY_RANKING_MAX_COUNT]: 3
+} as const;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -102,9 +102,9 @@ export const GUILD_SETTINGS_MAP = {
 export const GUILD_SETTINGS: Set<GuildSetting> = new Set(Object.values(GUILD_SETTINGS_MAP) as GuildSetting[]);
 
 export const FORMATTED_GUILD_SETTINGS = {
-    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_10]: 'Every 10th level-up starting level',
-    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_5]: 'Every 5th level-up starting level',
-    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_1]: 'Every level-up starting level',
+    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_10]: 'Broadcast every 10th level-up starting at',
+    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_5]: 'Broadcast every 5th level-up starting at',
+    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_1]: 'Broadcast every level-up starting at',
     [GUILD_SETTINGS_MAP.BOSSES_BROADCAST_INTERVAL]: 'Boss kills broadcast interval',
     [GUILD_SETTINGS_MAP.CLUES_BROADCAST_INTERVAL]: 'Clue completions broadcast interval',
     [GUILD_SETTINGS_MAP.MINIGAMES_BROADCAST_INTERVAL]: 'Minigame completions broadcast interval',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -90,9 +90,9 @@ export const DEFAULT_AXIOS_CONFIG: { timeout: number } = {
 };
 
 export const GUILD_SETTINGS_MAP = {
-    SKILLS_BROADCAST_EVERY_10: 'skills_broadcast_every_10',
-    SKILLS_BROADCAST_EVERY_5: 'skills_broadcast_every_5',
-    SKILLS_BROADCAST_EVERY_1: 'skills_broadcast_every_1',
+    // SKILLS_BROADCAST_EVERY_10: 'skills_broadcast_every_10',
+    // SKILLS_BROADCAST_EVERY_5: 'skills_broadcast_every_5',
+    // SKILLS_BROADCAST_EVERY_1: 'skills_broadcast_every_1',
     BOSSES_BROADCAST_INTERVAL: 'bosses_broadcast_interval',
     CLUES_BROADCAST_INTERVAL: 'clues_broadcast_interval',
     MINIGAMES_BROADCAST_INTERVAL: 'minigames_broadcast_interval',
@@ -102,9 +102,9 @@ export const GUILD_SETTINGS_MAP = {
 export const GUILD_SETTINGS: Set<GuildSetting> = new Set(Object.values(GUILD_SETTINGS_MAP) as GuildSetting[]);
 
 export const FORMATTED_GUILD_SETTINGS = {
-    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_10]: 'Broadcast every 10th level-up starting at',
-    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_5]: 'Broadcast every 5th level-up starting at',
-    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_1]: 'Broadcast every level-up starting at',
+    // [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_10]: 'Broadcast every 10th level-up starting at',
+    // [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_5]: 'Broadcast every 5th level-up starting at',
+    // [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_1]: 'Broadcast every level-up starting at',
     [GUILD_SETTINGS_MAP.BOSSES_BROADCAST_INTERVAL]: 'Boss kills broadcast interval',
     [GUILD_SETTINGS_MAP.CLUES_BROADCAST_INTERVAL]: 'Clue completions broadcast interval',
     [GUILD_SETTINGS_MAP.MINIGAMES_BROADCAST_INTERVAL]: 'Minigame completions broadcast interval',
@@ -112,9 +112,9 @@ export const FORMATTED_GUILD_SETTINGS = {
 } as const;
 
 export const DEFAULT_GUILD_SETTINGS = {
-    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_10]: 0,
-    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_5]: 0,
-    [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_1]: 1,
+    // [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_10]: 0,
+    // [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_5]: 0,
+    // [GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_1]: 1,
     [GUILD_SETTINGS_MAP.BOSSES_BROADCAST_INTERVAL]: 1,
     [GUILD_SETTINGS_MAP.CLUES_BROADCAST_INTERVAL]: 1,
     [GUILD_SETTINGS_MAP.MINIGAMES_BROADCAST_INTERVAL]: 1,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 import { PermissionFlagsBits } from 'discord.js';
 import { loadJson } from 'evanw555.js';
 import { Boss, CLUES, SKILLS, BOSSES, FORMATTED_SKILL_NAMES, FORMATTED_BOSS_NAMES, FORMATTED_LEAGUE_POINTS, FORMATTED_LMS, FORMATTED_PVP_ARENA, FORMATTED_SOUL_WARS, FORMATTED_RIFTS_CLOSED, FORMATTED_COLOSSEUM_GLORY } from 'osrs-json-hiscores';
-import { IndividualClueType, IndividualSkillName, ScapeBotAuth, ScapeBotConfig, ScapeBotConstants, CommandOptionChoice } from './types';
+import { IndividualClueType, IndividualSkillName, ScapeBotAuth, ScapeBotConfig, ScapeBotConstants, CommandOptionChoice, GuildSetting } from './types';
 
 export const SKILLS_NO_OVERALL: IndividualSkillName[] = SKILLS.filter(skill => skill !== 'overall') as IndividualSkillName[];
 export const CLUES_NO_ALL: IndividualClueType[] = CLUES.filter(clue => clue !== 'all') as IndividualClueType[];
@@ -87,4 +87,34 @@ export const UNAUTHORIZED_ROLE = 'err/unauthorized-role';
 
 export const DEFAULT_AXIOS_CONFIG: { timeout: number } = {
     timeout: 30000
+};
+
+export const GUILD_SETTINGS: Set<GuildSetting> = new Set([
+    'skills_broadcast_every_10',
+    'skills_broadcast_every_5',
+    'skills_broadcast_every_1',
+    'bosses_broadcast_interval',
+    'clues_broadcast_interval',
+    'minigames_broadcast_interval',
+    'weekly_ranking_max_count'
+]);
+
+export const FORMATTED_GUILD_SETTINGS: Record<GuildSetting, string> = {
+    'skills_broadcast_every_10': 'Broadcast skills every 10 levels up to this level',
+    'skills_broadcast_every_5': 'Broadcast skills every 5 levels up to this level',
+    'skills_broadcast_every_1': 'Broadcast skills every level up to this level',
+    'bosses_broadcast_interval': 'Broadcast boss kills at this interval',
+    'clues_broadcast_interval': 'Broadcast clue completions at this interval',
+    'minigames_broadcast_interval': 'Broadcast minigame completions at this interval',
+    'weekly_ranking_max_count': 'Number of players included in the weekly ranking'
+};
+
+export const DEFAULT_GUILD_SETTINGS: Record<GuildSetting, number> = {
+    'skills_broadcast_every_10': 0,
+    'skills_broadcast_every_5': 0,
+    'skills_broadcast_every_1': 99,     // Broadcast every level-up
+    'bosses_broadcast_interval': 1,     // Broadcast every boss kill
+    'clues_broadcast_interval': 1,      // Broadcast every clue completion
+    'minigames_broadcast_interval': 1,  // Broadcast every minigame completion
+    'weekly_ranking_max_count': 3       // Show the top 3 players in the weekly ranking
 };

--- a/src/pg-storage-client.ts
+++ b/src/pg-storage-client.ts
@@ -7,7 +7,7 @@ import { IndividualSkillName, IndividualClueType, IndividualActivityName, MiscPr
 
 import logger from './instances/logger';
 
-type TableName = 'weekly_xp_snapshots' | 'weekly_xp_snapshot_timestamps' | 'player_total_xp' | 'player_levels' | 'player_bosses' | 'player_clues' | 'player_activities' | 'tracked_players' | 'tracking_channels' | 'player_hiscore_status' | 'player_display_names' | 'player_activity_timestamps' | 'player_refresh_timestamps' | 'bot_counters' | 'privileged_roles' | 'daily_analytics' | 'misc_properties';
+type TableName = 'weekly_xp_snapshots' | 'weekly_xp_snapshot_timestamps' | 'player_total_xp' | 'player_levels' | 'player_bosses' | 'player_clues' | 'player_activities' | 'tracked_players' | 'tracking_channels' | 'player_hiscore_status' | 'player_display_names' | 'player_activity_timestamps' | 'player_refresh_timestamps' | 'bot_counters' | 'privileged_roles' | 'daily_analytics' | 'misc_properties' | 'guild_settings';
 
 export default class PGStorageClient {
     private static readonly TABLES: Record<TableName, string> = {
@@ -28,7 +28,8 @@ export default class PGStorageClient {
         'bot_counters': 'CREATE TABLE bot_counters (user_id BIGINT PRIMARY KEY, counter INTEGER);',
         'privileged_roles': 'CREATE TABLE privileged_roles (guild_id BIGINT PRIMARY KEY, role_id BIGINT);',
         'daily_analytics': 'CREATE TABLE daily_analytics (date DATE, label SMALLINT, value INTEGER, PRIMARY KEY (date, label));',
-        'misc_properties': 'CREATE TABLE misc_properties (name VARCHAR(32) PRIMARY KEY, value VARCHAR(2048));'
+        'misc_properties': 'CREATE TABLE misc_properties (name VARCHAR(32) PRIMARY KEY, value VARCHAR(2048));',
+        'guild_settings': 'CREATE TABLE guild_settings (guild_id BIGINT, setting VARCHAR(32), value SMALLINT, PRIMARY KEY (guild_id, setting));'
     };
 
     // List of tables that should be purged if the player corresponding to a row is missing from tracked_players
@@ -50,7 +51,8 @@ export default class PGStorageClient {
     private static readonly PURGEABLE_GUILD_TABLES: TableName[] = [
         'tracked_players',
         'tracking_channels',
-        'privileged_roles'
+        'privileged_roles',
+        'guild_settings'
     ];
 
     private readonly client: Client;

--- a/src/state.ts
+++ b/src/state.ts
@@ -583,6 +583,13 @@ export default class State {
         return this._settingsByGuild[guildId];
     }
 
+    getGuildSetting(guildId: string, setting: GuildSetting): number {
+        if (!this.hasGuildSettings(guildId)) {
+            throw new Error(`Trying to get guild setting for ${guildId} without there being pre-existing settings`);
+        }
+        return this._settingsByGuild[guildId][setting] as number;
+    }
+
     setGuildSetting(guildId: string, setting: GuildSetting, value: number): void {
         if (!this.hasGuildSettings(guildId)) {
             throw new Error(`Trying to set guild setting for ${guildId} without there being pre-existing settings`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,7 +59,7 @@ export interface SerializedGuildState {
 
 export type MiscPropertyName = 'timestamp' | 'disabled' | 'auditCounters' | typeof TIMEOUTS_PROPERTY;
 
-export type SlashCommandName = 'help' | 'ping' | 'info' | 'track' | 'remove' | 'clear' | 'list' | 'check' | 'channel' | 'kc' | 'details' | 'role' | 'settings';
+export type SlashCommandName = 'help' | 'ping' | 'info' | 'track' | 'remove' | 'clear' | 'list' | 'check' | 'channel' | 'kc' | 'details' | 'role';
 
 export type HiddenCommandName = 'help' | 'log' | 'thumbnail' | 'thumbnail99' | 'spoof' | 'spoofverbose' | 'admin' | 'kill' | 'enable' | 'rollback' | 'removeglobal' | 'logger' | 'player' | 'refresh' | 'guildnotify' | 'hiscoresurl';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType, ChatInputCommandInteraction, Message, SlashCommandBuilder, Snowflake } from 'discord.js';
+import { ApplicationCommandOptionType, ChatInputCommandInteraction, Message, Snowflake } from 'discord.js';
 import { MultiLoggerLevel } from 'evanw555.js';
 import { Boss, ClueType, Gamemode, SkillName } from 'osrs-json-hiscores';
 import { ClientConfig } from 'pg';
@@ -59,9 +59,7 @@ export interface SerializedGuildState {
 
 export type MiscPropertyName = 'timestamp' | 'disabled' | 'auditCounters' | typeof TIMEOUTS_PROPERTY;
 
-export type BuiltSlashCommand = SlashCommandBuilder | Omit<SlashCommandBuilder, 'addSubcommand' | 'addSubcommandGroup'>;
-
-export type SlashCommandName = 'help' | 'ping' | 'info' | 'track' | 'remove' | 'clear' | 'list' | 'check' | 'channel' | 'kc' | 'details' | 'role';
+export type SlashCommandName = 'help' | 'ping' | 'info' | 'track' | 'remove' | 'clear' | 'list' | 'check' | 'channel' | 'kc' | 'details' | 'role' | 'settings';
 
 export type HiddenCommandName = 'help' | 'log' | 'thumbnail' | 'thumbnail99' | 'spoof' | 'spoofverbose' | 'admin' | 'kill' | 'enable' | 'rollback' | 'removeglobal' | 'logger' | 'player' | 'refresh' | 'guildnotify' | 'hiscoresurl';
 
@@ -82,6 +80,12 @@ export interface CommandOption {
     choices?: CommandOptionChoice[]
 }
 
+export interface Subcommand {
+    name: string,
+    description: string,
+    options?: CommandOption[]
+}
+
 export interface Command {
     text: string,
     failIfDisabled?: boolean
@@ -89,6 +93,7 @@ export interface Command {
 
 export interface SlashCommand extends Command {
     options?: CommandOption[],
+    subcommands?: Subcommand[],
     execute: (interaction: ChatInputCommandInteraction) => Promise<boolean>,
     /**
      * If true, this command can only be invoked (and seen in help text) by guild admins (or bot maintainers).
@@ -108,6 +113,10 @@ export interface HiddenCommand extends Command {
 
 export interface CommandWithOptions extends SlashCommand {
     options: CommandOption[]
+}
+
+export interface CommandWithSubcommands extends SlashCommand {
+    subcommands: Subcommand[]
 }
 
 export interface ParsedCommand {
@@ -141,3 +150,5 @@ export enum DailyAnalyticsLabel {
 }
 
 export class NegativeDiffError extends Error {}
+
+export type GuildSetting =  'skills_broadcast_every_10' | 'skills_broadcast_every_5' | 'skills_broadcast_every_1' | 'bosses_broadcast_interval' | 'clues_broadcast_interval' | 'minigames_broadcast_interval' | 'weekly_ranking_max_count';

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,4 +154,4 @@ export enum DailyAnalyticsLabel {
 
 export class NegativeDiffError extends Error {}
 
-export type GuildSetting =  'skills_broadcast_every_10' | 'skills_broadcast_every_5' | 'skills_broadcast_every_1' | 'bosses_broadcast_interval' | 'clues_broadcast_interval' | 'minigames_broadcast_interval' | 'weekly_ranking_max_count';
+export type GuildSetting =  /*'skills_broadcast_every_10' | 'skills_broadcast_every_5' | 'skills_broadcast_every_1' | */'bosses_broadcast_interval' | 'clues_broadcast_interval' | 'minigames_broadcast_interval' | 'weekly_ranking_max_count';

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,8 @@ export type CommandsType = Record<string, Command>;
 export type SlashCommandsType = Record<SlashCommandName, SlashCommand>;
 export type HiddenCommandsType = Record<HiddenCommandName, HiddenCommand>;
 
+type CommandExecute = (interaction: ChatInputCommandInteraction) => Promise<boolean>;
+
 export interface CommandOptionChoice {
     name: string,
     value: string
@@ -83,7 +85,8 @@ export interface CommandOption {
 export interface Subcommand {
     name: string,
     description: string,
-    options?: CommandOption[]
+    options?: CommandOption[],
+    execute?: CommandExecute
 }
 
 export interface Command {
@@ -94,7 +97,7 @@ export interface Command {
 export interface SlashCommand extends Command {
     options?: CommandOption[],
     subcommands?: Subcommand[],
-    execute: (interaction: ChatInputCommandInteraction) => Promise<boolean>,
+    execute: CommandExecute,
     /**
      * If true, this command can only be invoked (and seen in help text) by guild admins (or bot maintainers).
      * Mutually exclusive with 'privilegedRole'.

--- a/src/util.ts
+++ b/src/util.ts
@@ -516,12 +516,18 @@ export async function updateLevels(rsn: string, newLevels: Record<IndividualSkil
     return false;
 }
 
+/**
+ * Takes a map of player activity scores, the diff, and an interval, and determines which new activity scores meet or
+ * exceed the next value in the interval, returning those keys in an array.
+ */
 export function filterToInterval(newScores: Record<string, number>, diff: Record<string, number>, interval: number) {
     const filteredKeys: string[] = [];
     for (const [key, value] of Object.entries(diff)) {
-        // Get the previous score for the activity and calculate what remains to equal or exceed interval
+        // New score must at least exceed interval
         if (newScores[key] >= interval) {
-            const remainder = (newScores[key] - value) % interval;
+            // Get the remainder needed to reach next interval multiple
+            const prevScore = newScores[key] - value;
+            const remainder = prevScore % interval || interval;
             // If diff value is greater than remainder, we can add to filtered keys
             if (value >= remainder) {
                 filteredKeys.push(key);
@@ -1012,12 +1018,12 @@ export function getReadableSettingValue(setting: GuildSetting, value: number, is
         valueStr = 'Disabled';
     } else {
         switch (setting) {
-        case GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_10:
-        case GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_5:
-        case GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_1: {
-            valueStr = `Level ${value}`;
-            break;
-        }
+        // case GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_10:
+        // case GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_5:
+        // case GUILD_SETTINGS_MAP.SKILLS_BROADCAST_EVERY_1: {
+        //     valueStr = `Level ${value}`;
+        //     break;
+        // }
         case GUILD_SETTINGS_MAP.BOSSES_BROADCAST_INTERVAL:
             valueStr = `Every${value !== 1 ? ` ${value}` : ''} kill${value !== 1 ? 's' : ''}`;
             break;

--- a/src/util.ts
+++ b/src/util.ts
@@ -574,8 +574,7 @@ export async function updateKillCounts(rsn: string, newScores: Record<Boss, numb
     const sendMessages = playerGuildIds.map(async (guildId) => {
         // Get the boss broadcast interval and filter out invalid boss updates
         const bossesIntervalSetting = GUILD_SETTINGS_MAP.BOSSES_BROADCAST_INTERVAL;
-        const bossesBroadcastInterval = state.getGuildSetting(guildId, bossesIntervalSetting)
-            || DEFAULT_GUILD_SETTINGS[bossesIntervalSetting];
+        const bossesBroadcastInterval = getGuildSettingOrDefault(guildId, bossesIntervalSetting);
         const guildBosses = filterToInterval(newScores, diff, bossesBroadcastInterval) as Boss[];
         // TODO: Save "skipped" boss updates per guild in database so we can get true delta when boss update passes interval check and is broadcast to guild
         const textChannel = state.getTrackingChannel(guildId);
@@ -684,8 +683,7 @@ export async function updateClues(rsn: string, newScores: Record<IndividualClueT
     const sendMessages = playerGuildIds.map(async (guildId) => {
         // Get the clue broadcast interval and filter out invalid clue updates
         const cluesIntervalSetting = GUILD_SETTINGS_MAP.CLUES_BROADCAST_INTERVAL;
-        const cluesBroadcastInterval = state.getGuildSetting(guildId, cluesIntervalSetting)
-            || DEFAULT_GUILD_SETTINGS[cluesIntervalSetting];
+        const cluesBroadcastInterval = getGuildSettingOrDefault(guildId, cluesIntervalSetting);
         const guildClues = filterToInterval(newScores, diff, cluesBroadcastInterval) as IndividualClueType[];
         const textChannel = state.getTrackingChannel(guildId);
         switch (guildClues.length) {
@@ -797,8 +795,7 @@ export async function updateActivities(rsn: string, newScores: Record<Individual
     const sendMessages = playerGuildIds.map(async (guildId) => {
         // Get the minigames broadcast interval and filter out invalid minigame updates
         const minigamesIntervalSetting = GUILD_SETTINGS_MAP.MINIGAMES_BROADCAST_INTERVAL;
-        const minigamesBroadcastInterval = state.getGuildSetting(guildId, minigamesIntervalSetting)
-            || DEFAULT_GUILD_SETTINGS[minigamesIntervalSetting];
+        const minigamesBroadcastInterval = getGuildSettingOrDefault(guildId, minigamesIntervalSetting);
         const guildMinigames = filterToInterval(newScores, diff, minigamesBroadcastInterval) as IndividualActivityName[];
         const textChannel = state.getTrackingChannel(guildId);
         switch (guildMinigames.length) {
@@ -1007,6 +1004,10 @@ export function generateDetailsContentString(players: string[]): string {
         }
     }
     return contentString;
+}
+
+export function getGuildSettingOrDefault(guildId: Snowflake, setting: GuildSetting): number {
+    return state.getGuildSetting(guildId, setting) ?? DEFAULT_GUILD_SETTINGS[setting];
 }
 
 /**


### PR DESCRIPTION
First of all, :oak: -

I got started on the guild-specific settings. The overall goal of this PR is to implement the table for guild settings + the methods for accessing that table, to create a good enough UI on the Discord end for configuring those settings, and to write the functionality for at least one of the settings added.

So far, I've settled on the design for the table we already discussed, and worked on a possibility for the Discord UI side of it using "subcommands". I personally think they're the best option for something like this, though our method of building commands makes implementing it this way a bit more annoying. Ideally, each subcommand should have its own `execute`, though I think we can be lazy and get away with *not* doing that in this case since each subcommand is doing more or less the same thing (update the relevant entry in guild_settings).

This is obviously a huge WIP, though next I'll probably work on the `execute` function which will add rows to the guild_settings table. Afterwards, we clean things up, make better use of constants, and start thinking about how we actually apply these settings to the functionality of the app.